### PR TITLE
fix(yt-dlp): add missing download functionality to the ytdownloader f…

### DIFF
--- a/ytdownloader.py
+++ b/ytdownloader.py
@@ -5,11 +5,14 @@ def ytdownloader(url):
         ydl_opts = {
             'merge_output_format': 'mp4',
             'outtmpl': '%(title)s.%(ext)s',
-            'concurrent_fragments': '8',
-            'throttled-rate': '0',
+            'concurrent_fragments': 8,
+            'throttled-rate': 0,
             'external_downloader_args': ['-multi_thread', '-threads', '0'],
             'quiet': True,
         }
+        
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            ydl.download([url])
         
         print('Download completed.')
     
@@ -19,4 +22,4 @@ def ytdownloader(url):
 
 # Example usage
 url = input('Enter the URL of the YouTube video: ')
-resolution = ytdownloader(url)
+ytdownloader(url)


### PR DESCRIPTION
# Pull Request: Fix Missing Download Functionality in `ytdownloader`

## Summary

This pull request addresses a critical issue in the `ytdownloader` function where the download functionality was missing. The function was correctly configured with options for `yt-dlp`, but it lacked the actual implementation to download the video. This fix includes the necessary logic to perform the download using the `yt_dlp` library.

## Changes Made

- Added the `yt_dlp.YoutubeDL` object creation.
- Implemented the `ydl.download([url])` method to perform the download.
- Fixed the type of `concurrent_fragments` and `throttled-rate` options to integer